### PR TITLE
26 fix fix category names not being merged

### DIFF
--- a/src/app/hooks/useGetYearGraphData.tsx
+++ b/src/app/hooks/useGetYearGraphData.tsx
@@ -4,34 +4,34 @@ import { APP } from '@/utils/app.constants';
 
 const useGetYearGraphData = (yearData: IYear) => {
   function getBarData(yearData: IYear, eventType: string) {
-    const incomes = getYearIncomesExpensesBarData(yearData.incomes);
-    const expenses = getYearIncomesExpensesBarData(yearData.expenses);
+    const incomesObj = getYearIncomesExpensesBarData(yearData.incomes);
+    const expensesObj = getYearIncomesExpensesBarData(yearData.expenses);
     const isExpenses = eventType === APP.eventType.expense ? true : false;
-    const allMonthNamesInIncomes = Object.keys(incomes);
-    const allMonthNamesInExpenses = Object.keys(expenses);
+    const allMonthNamesInIncomes = Object.keys(incomesObj);
+    const allMonthNamesInExpenses = Object.keys(expensesObj);
     const isExpensesBiggerThanIncomes = allMonthNamesInExpenses.length > allMonthNamesInIncomes.length;
-    const listWithoutAllMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInIncomes : allMonthNamesInExpenses;
-    const listWithAllMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInExpenses : allMonthNamesInIncomes;
-    const incomesExpenseObj: { [monthName: string]: number } = {};
+    const listWithLessMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInIncomes : allMonthNamesInExpenses;
+    const listWithMoreMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInExpenses : allMonthNamesInIncomes;
+    const incomesExpensesObj: { [monthName: string]: number } = {};
 
     // expense include all existing month names
     if (isExpenses && isExpensesBiggerThanIncomes) {
-      return expenses;
+      return expensesObj;
     }
     // income includes all existing month names
     if (!isExpenses && !isExpensesBiggerThanIncomes) {
-      return incomes;
+      return incomesObj;
     }
 
-    listWithAllMonthNames.forEach((monthName) => {
-      if (listWithoutAllMonthNames.includes(monthName)) {
-        incomesExpenseObj[monthName] = isExpenses ? expenses[monthName] : incomes[monthName];
+    listWithMoreMonthNames.forEach((monthName) => {
+      if (listWithLessMonthNames.includes(monthName)) {
+        incomesExpensesObj[monthName] = isExpenses ? expensesObj[monthName] : incomesObj[monthName];
       } else {
-        incomesExpenseObj[monthName] = 0;
+        incomesExpensesObj[monthName] = 0;
       }
     });
 
-    return incomesExpenseObj;
+    return incomesExpensesObj;
   }
 
   const incomeBarData = Object.values(getBarData(yearData, APP.eventType.income));

--- a/src/app/hooks/useGetYearGraphData.tsx
+++ b/src/app/hooks/useGetYearGraphData.tsx
@@ -1,0 +1,48 @@
+import { getYearIncomesExpensesBarData } from '@/utils/app.methods';
+import { IYear } from '@/types/models';
+import { APP } from '@/utils/app.constants';
+
+const useGetYearGraphData = (yearData: IYear) => {
+  function getBarData(yearData: IYear, eventType: string) {
+    const incomes = getYearIncomesExpensesBarData(yearData.incomes);
+    const expenses = getYearIncomesExpensesBarData(yearData.expenses);
+    const isExpenses = eventType === APP.eventType.expense ? true : false;
+    const allMonthNamesInIncomes = Object.keys(incomes);
+    const allMonthNamesInExpenses = Object.keys(expenses);
+    const isExpensesBiggerThanIncomes = allMonthNamesInExpenses.length > allMonthNamesInIncomes.length;
+    const listWithoutAllMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInIncomes : allMonthNamesInExpenses;
+    const listWithAllMonthNames = isExpensesBiggerThanIncomes ? allMonthNamesInExpenses : allMonthNamesInIncomes;
+    const incomesExpenseObj: { [monthName: string]: number } = {};
+
+    // expense include all existing month names
+    if (isExpenses && isExpensesBiggerThanIncomes) {
+      return expenses;
+    }
+    // income includes all existing month names
+    if (!isExpenses && !isExpensesBiggerThanIncomes) {
+      return incomes;
+    }
+
+    listWithAllMonthNames.forEach((monthName) => {
+      if (listWithoutAllMonthNames.includes(monthName)) {
+        incomesExpenseObj[monthName] = isExpenses ? expenses[monthName] : incomes[monthName];
+      } else {
+        incomesExpenseObj[monthName] = 0;
+      }
+    });
+
+    return incomesExpenseObj;
+  }
+
+  const incomeBarData = Object.values(getBarData(yearData, APP.eventType.income));
+  const expenseBarData = Object.values(getBarData(yearData, APP.eventType.expense));
+  const monthNames = Object.keys(getBarData(yearData, APP.eventType.expense));
+
+  return {
+    incomeBarData,
+    expenseBarData,
+    monthNames,
+  };
+};
+
+export default useGetYearGraphData;

--- a/src/components/YearCategoryGraph.tsx
+++ b/src/components/YearCategoryGraph.tsx
@@ -14,7 +14,7 @@ export const options = {
     },
     title: {
       display: false,
-      text: '2030',
+      text: '2023',
     },
   },
 };

--- a/src/components/YearCategoryGraph.tsx
+++ b/src/components/YearCategoryGraph.tsx
@@ -1,7 +1,7 @@
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import { IYear } from '@/types/models';
-import { getYearIncomesExpensesBarData } from '@/utils/app.methods';
+import useGetYearGraphData from '@/app/hooks/useGetYearGraphData';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 ChartJS.defaults.color = '#F3F4F6';
@@ -14,69 +14,25 @@ export const options = {
     },
     title: {
       display: false,
-      text: '2023',
+      text: '2030',
     },
   },
 };
 
 const YearCategoriesGraph = ({ currentYear }: { currentYear: IYear }): JSX.Element => {
-  const incomes = getYearIncomesExpensesBarData(currentYear.incomes);
-  const expenses = getYearIncomesExpensesBarData(currentYear.expenses);
-  const monthNamesWithIncomes = Object.keys(incomes);
-  const monthNamesWithExpenses = Object.keys(expenses);
-  const isIncomeBiggerThanExpenses = monthNamesWithIncomes.length > monthNamesWithExpenses.length;
-
-  function getGraphLabels() {
-    return Object.keys(isIncomeBiggerThanExpenses ? incomes : expenses);
-  }
-
-  function getIncomesBarData() {
-    const incomesExpenseObj: { [monthName: string]: number } = {};
-
-    if (isIncomeBiggerThanExpenses) {
-      return incomes;
-    }
-
-    monthNamesWithExpenses.forEach((monthName) => {
-      if (!monthNamesWithIncomes.includes(monthName)) {
-        incomesExpenseObj[monthName] = 0;
-      } else {
-        incomesExpenseObj[monthName] = incomes[monthName];
-      }
-    });
-
-    return incomesExpenseObj;
-  }
-
-  function getExpensesBarData() {
-    const incomesExpenseObj: { [monthName: string]: number } = {};
-
-    if (!isIncomeBiggerThanExpenses) {
-      return expenses;
-    }
-
-    monthNamesWithIncomes.forEach((monthName) => {
-      if (!monthNamesWithExpenses.includes(monthName)) {
-        incomesExpenseObj[monthName] = 0;
-      } else {
-        incomesExpenseObj[monthName] = expenses[monthName];
-      }
-    });
-
-    return incomesExpenseObj;
-  }
+  const { incomeBarData, expenseBarData, monthNames } = useGetYearGraphData(currentYear);
 
   const data = {
-    labels: getGraphLabels(),
+    labels: monthNames,
     datasets: [
       {
         label: 'Incomes',
-        data: Object.values(getIncomesBarData()),
+        data: incomeBarData,
         backgroundColor: '#21C55D',
       },
       {
         label: 'Expenses',
-        data: Object.values(getExpensesBarData()),
+        data: expenseBarData,
         backgroundColor: '#EF4444',
       },
     ],

--- a/src/components/YearCategoryGraph.tsx
+++ b/src/components/YearCategoryGraph.tsx
@@ -22,18 +22,61 @@ export const options = {
 const YearCategoriesGraph = ({ currentYear }: { currentYear: IYear }): JSX.Element => {
   const incomes = getYearIncomesExpensesBarData(currentYear.incomes);
   const expenses = getYearIncomesExpensesBarData(currentYear.expenses);
+  const monthNamesWithIncomes = Object.keys(incomes);
+  const monthNamesWithExpenses = Object.keys(expenses);
+  const isIncomeBiggerThanExpenses = monthNamesWithIncomes.length > monthNamesWithExpenses.length;
+
+  function getGraphLabels() {
+    return Object.keys(isIncomeBiggerThanExpenses ? incomes : expenses);
+  }
+
+  function getIncomesBarData() {
+    const incomesExpenseObj: { [monthName: string]: number } = {};
+
+    if (isIncomeBiggerThanExpenses) {
+      return incomes;
+    }
+
+    monthNamesWithExpenses.forEach((monthName) => {
+      if (!monthNamesWithIncomes.includes(monthName)) {
+        incomesExpenseObj[monthName] = 0;
+      } else {
+        incomesExpenseObj[monthName] = incomes[monthName];
+      }
+    });
+
+    return incomesExpenseObj;
+  }
+
+  function getExpensesBarData() {
+    const incomesExpenseObj: { [monthName: string]: number } = {};
+
+    if (!isIncomeBiggerThanExpenses) {
+      return expenses;
+    }
+
+    monthNamesWithIncomes.forEach((monthName) => {
+      if (!monthNamesWithExpenses.includes(monthName)) {
+        incomesExpenseObj[monthName] = 0;
+      } else {
+        incomesExpenseObj[monthName] = expenses[monthName];
+      }
+    });
+
+    return incomesExpenseObj;
+  }
 
   const data = {
-    labels: Object.keys(incomes),
+    labels: getGraphLabels(),
     datasets: [
       {
         label: 'Incomes',
-        data: Object.values(incomes),
+        data: Object.values(getIncomesBarData()),
         backgroundColor: '#21C55D',
       },
       {
         label: 'Expenses',
-        data: Object.values(expenses),
+        data: Object.values(getExpensesBarData()),
         backgroundColor: '#EF4444',
       },
     ],

--- a/src/utils/app.methods.ts
+++ b/src/utils/app.methods.ts
@@ -1,14 +1,21 @@
 import { IExpense, IIncome, IMonth, IYear } from '@/types/models';
 import { format } from 'date-fns';
 import { capitalize } from 'lodash';
-import { APP } from './app.constants';
+import { APP } from '@/utils/app.constants';
 
 export const calculateTotal = (incomeExpenseList: IExpense[] | IIncome[]): number => {
   let total = 0;
   incomeExpenseList.forEach((element) => {
     total += element.amount;
   });
-  return Number(total.toFixed(2));
+  return Number(getFormatedAmountToDisplay(total));
+};
+
+export const getFormatedAmountToDisplay = (amount: number) => {
+  if (amount % 1 === 0) {
+    return amount;
+  }
+  return amount.toFixed(2);
 };
 export const getMonthBalance = (month: IMonth | IYear): number => {
   let totalIncome = calculateTotal(month.incomes);
@@ -36,10 +43,11 @@ export const getCategoryTotals = (incomeExpenseList: (IIncome | IExpense)[]): { 
 
   for (const item of incomeExpenseList) {
     const { category, amount } = item;
-    if (category in categoryTotals) {
-      categoryTotals[category] += amount;
+    const categoryName = capitalize(category).trim();
+    if (categoryName in categoryTotals) {
+      categoryTotals[categoryName] += amount;
     } else {
-      categoryTotals[category] = amount;
+      categoryTotals[categoryName] = amount;
     }
   }
 
@@ -64,11 +72,11 @@ export const getCategoryNamestoShow = (incomeExpenseList: IIncome[] | IExpense[]
 };
 
 export const getCategoryPercentage = (total: number, amount: number) => {
-  if (total <= 0) {
+  if (total < 0) {
     throw new Error('Total must be a positive number.');
   }
   const percentage = (amount / total) * 100;
-  return percentage.toFixed(2) + '%';
+  return getFormatedAmountToDisplay(percentage) + '%';
 };
 
 export const getGraphColors = (categoryType: string): string[] => {


### PR DESCRIPTION
### PR description
- Fixes same name of category being displayed more than in month details
- Fixes months without income not being displayed in the year bar graph
- Create function to format amount to be have 2 decimal number when amount ends like -> `11.3€`
<img width="605" alt="Screenshot 2023-07-06 at 15 12 33" src="https://github.com/vitor-afonso/budget-manager-nextjs/assets/69796068/8ce91600-6c6b-44a3-8bd8-4aee3a08b870">


