### PR TITLE
remove category name under income amount

### DIFF
--- a/src/components/IncomeExpense.tsx
+++ b/src/components/IncomeExpense.tsx
@@ -51,7 +51,7 @@ export function IncomeExpense({ incomeExpense, eventType }: Props) {
       <div className="flex items-center text-md">
         <div className="text-right leading-none">
           <p>{APP.currency.format(incomeExpense.amount)}</p>
-          <span className="text-xs capitalize">{incomeExpense.category}</span>
+          {isExpense && <span className="text-xs capitalize">{incomeExpense.category}</span>}
         </div>
         <button
           className="rounded-full bg-slate-300 w-5 h-5 flex justify-center items-center mx-1"


### PR DESCRIPTION
Removed category name under income amount.

![image](https://github.com/vitor-afonso/budget-manager-nextjs/assets/95537845/19ded332-4f34-4356-aa1e-ae30027000c4)
