### PR TITLE
Display month with no income/expense in year graph

### DIFF
--- a/src/app/hooks/useGetYearGraphData.tsx
+++ b/src/app/hooks/useGetYearGraphData.tsx
@@ -2,40 +2,19 @@ import { getYearIncomesExpensesBarData } from '@/utils/app.methods';
 import { IYear } from '@/types/models';
 import { APP } from '@/utils/app.constants';
 
-const useGetYearGraphData = (yearData: IYear) => {
+const useGetYearGraphData = (yearData: IYear, allOpenMonths: Date[]) => {
+
   function getBarData(yearData: IYear, eventType: string) {
-    const incomesObj = getYearIncomesExpensesBarData(yearData.incomes);
-    const expensesObj = getYearIncomesExpensesBarData(yearData.expenses);
+    const allMonthNames = allOpenMonths.map(date => APP.monthsOfTheYear[date.getMonth()])
+    const incomesObj = getYearIncomesExpensesBarData(yearData.incomes, allMonthNames);
+    const expensesObj = getYearIncomesExpensesBarData(yearData.expenses, allMonthNames);
     const isExpenses = eventType === APP.eventType.expense ? true : false;
-    const allMonthNamesInIncomes = Object.keys(incomesObj);
-    const allMonthNamesInExpenses = Object.keys(expensesObj);
-    const isExpensesBiggerThanIncomes =
-      allMonthNamesInExpenses.length > allMonthNamesInIncomes.length;
-    const listWithLessMonthNames = isExpensesBiggerThanIncomes
-      ? allMonthNamesInIncomes
-      : allMonthNamesInExpenses;
-    const listWithMoreMonthNames = isExpensesBiggerThanIncomes
-      ? allMonthNamesInExpenses
-      : allMonthNamesInIncomes;
     const incomesExpensesObj: { [monthName: string]: number } = {};
 
-    // expense include all existing month names
-    if (isExpenses && isExpensesBiggerThanIncomes) {
-      return expensesObj;
-    }
-    // income includes all existing month names
-    if (!isExpenses && !isExpensesBiggerThanIncomes) {
-      return incomesObj;
-    }
-
-    listWithMoreMonthNames.forEach((monthName) => {
-      if (listWithLessMonthNames.includes(monthName)) {
-        incomesExpensesObj[monthName] = isExpenses
+    allMonthNames.forEach((monthName) => {
+      incomesExpensesObj[monthName] = isExpenses
           ? expensesObj[monthName]
           : incomesObj[monthName];
-      } else {
-        incomesExpensesObj[monthName] = 0;
-      }
     });
 
     return incomesExpensesObj;

--- a/src/app/year/page.tsx
+++ b/src/app/year/page.tsx
@@ -12,9 +12,10 @@ import YearCategoriesGraph from '@/components/YearCategoryGraph';
 import YearCategoryTotals from '@/components/YearCategoryTotals';
 
 const YearInfo = () => {
-  const { userYears } = useContext(UserDataContext) as IUserDataContext;
+  const { userYears, userMonths } = useContext(UserDataContext) as IUserDataContext;
   const [currentYear, setCurrentYear] = useState<IYear | null>(null);
   const [yearIndex, setYearIndex] = useState<number | null>(null);
+  const [allOpenMonths, setAllOpenMonths] = useState<Date[] | null>(null);
 
   // set current month
   useEffect(() => {
@@ -29,8 +30,10 @@ const YearInfo = () => {
       if (year) {
         setCurrentYear(year);
       }
+
+      setAllOpenMonths(userMonths.map(month => month.createdAt))
     }
-  }, [userYears]);
+  }, [userYears, userMonths]);
 
   return (
     <div className="flex flex-col items-center">
@@ -44,7 +47,7 @@ const YearInfo = () => {
             setCurrentMonthYear={setCurrentYear}
             setIndex={setYearIndex}
           />
-          <YearCategoriesGraph currentYear={currentYear} />
+          <YearCategoriesGraph currentYear={currentYear} allOpenMonths={allOpenMonths!}/>
           <YearCategoryTotals
             eventType={APP.eventType.income}
             incomesExpenses={currentYear.incomes}

--- a/src/components/YearCategoryGraph.tsx
+++ b/src/components/YearCategoryGraph.tsx
@@ -34,13 +34,14 @@ export const options = {
   },
 };
 
-const YearCategoriesGraph = ({
-  currentYear,
-}: {
+interface Props {
   currentYear: IYear;
-}): JSX.Element => {
+  allOpenMonths: Date[];
+}
+
+const YearCategoriesGraph = ({ currentYear, allOpenMonths}: Props): JSX.Element => {
   const { incomeBarData, expenseBarData, monthNames } =
-    useGetYearGraphData(currentYear);
+    useGetYearGraphData(currentYear, allOpenMonths);
 
   const data = {
     labels: monthNames,

--- a/src/utils/app.methods.ts
+++ b/src/utils/app.methods.ts
@@ -128,21 +128,26 @@ export const changeMonthYear = (
 };
 
 export const getYearIncomesExpensesBarData = (
-  yearIncomeExpenses: IIncome[] | IExpense[],
+  yearIncomeExpenses: IIncome[] | IExpense[], allOpenMonths: string[]
 ) => {
-  const categoryTotals: { [category: string]: number } = {};
-
+  const allMonthsTotals: { [month: string]: number } = {};
   for (const item of yearIncomeExpenses) {
     const { createdAt, amount } = item;
     const monthIndex = new Date(createdAt).getUTCMonth();
-    if (APP.monthsOfTheYear[monthIndex] in categoryTotals) {
-      categoryTotals[APP.monthsOfTheYear[monthIndex]] += amount;
+    if (APP.monthsOfTheYear[monthIndex] in allMonthsTotals) {
+      allMonthsTotals[APP.monthsOfTheYear[monthIndex]] += amount;
     } else {
-      categoryTotals[APP.monthsOfTheYear[monthIndex]] = amount;
+      allMonthsTotals[APP.monthsOfTheYear[monthIndex]] = amount;
+    }
+  }
+  // add month with value of 0 if no income/expense exist
+  for (const monthName of allOpenMonths) {
+    if(!Object.keys(allMonthsTotals).includes(monthName)){
+      allMonthsTotals[monthName] = 0;
     }
   }
 
-  return categoryTotals;
+  return allMonthsTotals;
 };
 
 export const getMinMaxDate = (date: Date, minMax: string): string => {


### PR DESCRIPTION
### PR Description

Fixes months that have no incomes or expenses not being displayed in graph bar at Year Details page
<img width="299" alt="Screenshot 2023-11-01 at 16 15 49" src="https://github.com/vitor-afonso/budget-manager-nextjs/assets/69796068/c8e27b21-b353-4ec0-8b55-4619c53c285d">
